### PR TITLE
fix: Wall mounted lamps can be placed on DU walls

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_D_Env.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_D_Env.xml
@@ -60,6 +60,7 @@
     </costList>
     <building>
       <isInert>true</isInert>
+      <supportsWallAttachments>true</supportsWallAttachments>
       <blueprintGraphicData>
         <texPath>Things/Building/Linked/Wall_Blueprint_Atlas</texPath>
       </blueprintGraphicData>


### PR DESCRIPTION
Added a line: now wall mounted lights can be placed on Depleted Uranium Walls added by mod